### PR TITLE
[NO-TICKET] Use recommended image size in example app

### DIFF
--- a/server.js
+++ b/server.js
@@ -80,7 +80,7 @@ app.post('/ad', (req, res) => {
         color = colors.showcase;
     }
 
-    const imageURL = `https://via.placeholder.com/320x100/${color}/FFFFFF.png?text=${encodeURI(`Ad for ${user}`)}`;
+    const imageURL = `https://via.placeholder.com/1200x628/${color}/FFFFFF.png?text=${encodeURI(`Ad for ${user}`)}`;
     let redirectURL = `${baseURL}/landing-page`;
 
     // By adding the user_id as a query parameter in the redirect url here,


### PR DESCRIPTION
This updates the placeholder URL to use our recommended ad image size. This will make the images on our dev apps look sharper and more accurate. It will also help integrators.